### PR TITLE
feature/codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS 
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @garyedwards and @gnathoir will be requested for
+# review when someone opens a pull request.
+* @garyedwards @gnathoi


### PR DESCRIPTION
All files are now branch protected on a pull request into main by the addition of a branch protection rule and `.github/CODEOWNERS` file.