### PR TITLE
feature/xsd_schema

### DIFF
--- a/alignments/alignments.ttl
+++ b/alignments/alignments.ttl
@@ -21,3 +21,5 @@ sosa:Result
 qudt:QuantityValue 
     rdfs:subClassOf dob:Result ;
 .
+
+xsd:string owl:equivalentClass schema:Text .

--- a/alignments/alignments.ttl
+++ b/alignments/alignments.ttl
@@ -21,5 +21,6 @@ sosa:Result
 qudt:QuantityValue 
     rdfs:subClassOf dob:Result ;
 .
-
-xsd:string owl:equivalentClass schema:Text .
+xsd:string 
+    owl:equivalentClass schema:Text ;
+.


### PR DESCRIPTION
Explicit alignment between xsd:string and schema:Text,  there does not appear to be any accepted formal mapping between xsd and schema.

Closes DOB-19