### PR TITLE
feature/so_schema

### DIFF
--- a/alignments/alignments.ttl
+++ b/alignments/alignments.ttl
@@ -11,7 +11,7 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix schema: <http://schema.org/> .
+@prefix so: <http://schema.org/> .
 @prefix dob: <https://w3id.org/dob/voc/> .
 
 
@@ -22,5 +22,5 @@ qudt:QuantityValue
     rdfs:subClassOf dob:Result ;
 .
 xsd:string 
-    owl:equivalentClass schema:Text ;
+    owl:equivalentClass so:Text ;
 .

--- a/docs/examples/asset_descriptions.ttl
+++ b/docs/examples/asset_descriptions.ttl
@@ -1,30 +1,30 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix schema: <http://schema.org/> .
+@prefix so: <http://schema.org/> .
 @prefix exif: <http://www.w3.org/2003/12/exif/ns#> .
 @prefix dob: <https://w3id.org/dob/voc#> .
 @prefix did: <https://w3id.org/dob/id/> .
 
 did:result_6e2dce6a-b941-4bc4-be09-977a02221b31
     a dob:Result,
-      schema:ImageObject ;
-    schema:contentUrl <https://example.com/v1/result/6e2dce6a-b941-4bc4-be09-977a02221b31> ;
-    schema:thumbnailUrl <https://example.com/v1/result/6e2dce6a-b941-4bc4-be09-977a02221b31> ;
-    schema:encodingFormat "image/webp" ;
-    schema:width "640"^^xsd:integer ;
+      so:ImageObject ;
+    so:contentUrl <https://example.com/v1/result/6e2dce6a-b941-4bc4-be09-977a02221b31> ;
+    so:thumbnailUrl <https://example.com/v1/result/6e2dce6a-b941-4bc4-be09-977a02221b31> ;
+    so:encodingFormat "image/webp" ;
+    so:width "640"^^xsd:integer ;
     exif:colorSpace "sRGB" .
 
 did:result_2aa43a2e-cb51-46db-b298-cddbc52ffc60
     a dob:Result,
-      schema:ImageObject ;
-    schema:contentUrl <https://example.com/v1/result/2aa43a2e-cb51-46db-b298-cddbc52ffc60> ;
-    schema:thumbnailUrl <https://example.com/v1/result/2aa43a2e-cb51-46db-b298-cddbc52ffc60> ;
-    schema:encodingFormat "image/webp" ;
-    schema:width "640"^^xsd:integer ;
+      so:ImageObject ;
+    so:contentUrl <https://example.com/v1/result/2aa43a2e-cb51-46db-b298-cddbc52ffc60> ;
+    so:thumbnailUrl <https://example.com/v1/result/2aa43a2e-cb51-46db-b298-cddbc52ffc60> ;
+    so:encodingFormat "image/webp" ;
+    so:width "640"^^xsd:integer ;
     exif:colorSpace "sRGB" .
 
 did:result_64eae5e1-8cca-42d1-ac2e-9c65489d2930
     a dob:Result,
-      schema:DataDownload ;
-    schema:contentUrl <https://example.com/v1/result/64eae5e1-8cca-42d1-ac2e-9c65489d2930> ;
-    schema:encodingFormat "application/x-npz" ;
-    schema:width "640"^^xsd:integer .
+      so:DataDownload ;
+    so:contentUrl <https://example.com/v1/result/64eae5e1-8cca-42d1-ac2e-9c65489d2930> ;
+    so:encodingFormat "application/x-npz" ;
+    so:width "640"^^xsd:integer .

--- a/docs/examples/nhs_ods.ttl
+++ b/docs/examples/nhs_ods.ttl
@@ -1,4 +1,4 @@
-@prefix schema: <http://schema.org/> .
+@prefix so: <http://schema.org/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix dob: <https://w3id.org/dob/voc#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -45,9 +45,9 @@ did:SoftwarePipeline_AIMS_5f4fc6e
 
 did:CodeRepository_AIMS
     a dob:CodeRepository ;
-    schema:name "AIMS 1 Scala API" ;
-    schema:codeRepository "https://github.com/ONSdigital/aims-api" ;
-    schema:license "MIT" ;
+    so:name "AIMS 1 Scala API" ;
+    so:codeRepository "https://github.com/ONSdigital/aims-api" ;
+    so:license "MIT" ;
     dob:hasCodeRevision did:CodeRevision_AIMS_5f4fc6e .
 
 did:CodeRevision_AIMS_5f4fc6e
@@ -57,18 +57,18 @@ did:CodeRevision_AIMS_5f4fc6e
 did:zone_550e8400-e29b-41d4-a716-446655440000
     a sosa:FeatureOfInterest,
       bot:Zone ;
-    schema:identifier did:uprn_100021907534 ;
-    schema:identifier did:ods_S2R6V .
+    so:identifier did:uprn_100021907534 ;
+    so:identifier did:ods_S2R6V .
 
 did:uprn_100021907534
     a dob:UPRNValue ;
     prov:hadPrimarySource did:OS_Open_UPRN_August2024 ;
-    schema:value "100021907534" .
+    so:value "100021907534" .
 
 did:ods_S2R6V
     a dob:ODSValue ;
     prov:hadPrimarySource did:NHS_ODS_February2025 ;
     prov:wasGeneratedBy did:SoftwarePipeline_AIMS_5f4fc6e ;
-    schema:valueReference "Accept result"^^xsd:string ;
+    so:valueReference "Accept result"^^xsd:string ;
     # schema:valueReference "Requires clerical intervention"^^xsd:string ;
-    schema:value "S2R6V" .
+    so:value "S2R6V" .

--- a/voc/index.ttl
+++ b/voc/index.ttl
@@ -10,7 +10,7 @@
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix schema: <http://schema.org/> .
+@prefix so: <http://schema.org/> .
 @prefix dob: <https://w3id.org/dob/voc#> .
 
 ###################################################
@@ -19,7 +19,7 @@
 
 dob: a owl:Ontology ;
     dct:title "Open Built Environment Data Ontology"@en ;
-    owl:imports prov:, sosa:, ssn:, bot:, dcat:, dct:, schema:;
+    owl:imports prov:, sosa:, ssn:, bot:, dcat:, dct:, so:;
     dct:license <http://creativecommons.org/licenses/by/4.0/> ;
     dct:creator [
         a foaf:Organization ;
@@ -66,7 +66,7 @@ dob:PropertyValue a owl:Class ;
     rdfs:label "Property Value"@en ;
     rdfs:comment "A property value is a specific value of a property of an entity."@en ;
     rdfs:subClassOf prov:Entity ,
-                    schema:PropertyValue .
+                    so:PropertyValue .
 
 dob:UPRNValue a owl:Class ;
     rdfs:label "Unique Property Reference Number"@en ;
@@ -75,7 +75,7 @@ dob:UPRNValue a owl:Class ;
     rdfs:subClassOf dob:PropertyValue ,
                     [           
                         a owl:Restriction ;
-                        owl:onProperty schema:propertyID ;
+                        owl:onProperty so:propertyID ;
                         owl:hasValue "UPRN"^^xsd:string
                     ] .
 
@@ -87,7 +87,7 @@ dob:ODSValue a owl:Class ;
     rdfs:subClassOf dob:PropertyValue ,
                     [           
                         a owl:Restriction ;
-                        owl:onProperty schema:propertyID ;
+                        owl:onProperty so:propertyID ;
                         owl:hasValue "ODS"^^xsd:string
                     ] .
 
@@ -95,19 +95,19 @@ dob:SoftwarePipeline a owl:Class ;
     rdfs:label "Software Pipeline"@en ;
     rdfs:comment "A software-based workflow or pipeline that can be used by an Activity, specializing prov:Plan."@en ;
     rdfs:subClassOf prov:Plan ,
-                    schema:SoftwareApplication .
+                    so:SoftwareApplication .
 
 dob:CodeRepository a owl:Class ;
     rdfs:label "Code Repository"@en ;
     rdfs:comment "A repository (e.g., Git) containing source code for a software pipeline."@en ;
     rdfs:subClassOf prov:Entity ,
-                    schema:SoftwareSourceCode .
+                    so:SoftwareSourceCode .
 
 dob:CodeRevision a owl:Class ;
     rdfs:label "Code Revision"@en ;
     rdfs:comment "A specific tagged revision of code in a repository."@en ;
     rdfs:subClassOf prov:Entity ,
-                    schema:SoftwareSourceCode ,
+                    so:SoftwareSourceCode ,
                     [
                         a owl:Restriction ;
                         owl:onProperty dob:tagURI ;
@@ -122,7 +122,7 @@ dob:CodeRevision a owl:Class ;
 dob:tagURI a owl:DatatypeProperty ;
     rdfs:label "tag URL"@en ;
     rdfs:comment "A full external link for the tag (e.g., on GitHub)."@en ;
-    rdfs:subPropertyOf schema:url ;
+    rdfs:subPropertyOf so:url ;
     rdfs:domain dob:CodeRevision ;
     rdfs:range xsd:anyURI .
 
@@ -130,7 +130,7 @@ dob:hasCodeRevision a owl:ObjectProperty ;
     rdfs:label "has code revision"@en ;
     rdfs:comment "Links a Code Repository to the Code Revisions it contains."@en ;
     rdfs:subPropertyOf prov:wasRevisionOf ,
-                       schema:hasPart ;   
+                       so:hasPart ;   
     rdfs:domain dob:CodeRepository ;
     rdfs:range dob:CodeRevision .
 
@@ -144,7 +144,7 @@ dob:usedCodeRevision a owl:ObjectProperty ;
 dob:recommendationCode a owl:DatatypeProperty;
     rdfs:label "A generic value reference for confidence in matching identifiers."@en ;
     rdfs:comment "A code that represents the recommendation a matching process. One should sub-property this for specific recommendation codes and add restrictions to the valid codes of the process."@en ;
-    rdfs:subPropertyOf schema:valueReference ;
+    rdfs:subPropertyOf so:valueReference ;
     rdfs:domain dob:PropertyValue ;
     rdfs:range xsd:string .
 


### PR DESCRIPTION
Changing schema prefix from schema: to so: to avoid the rdflib schema naming collision. Code needs to be reviewed to make sure this is updated in ttl file generating code.

Closes DOB-22